### PR TITLE
Fix Google OAuth "Third-Party Login Failure" in production

### DIFF
--- a/crank/settings/base.py
+++ b/crank/settings/base.py
@@ -97,7 +97,6 @@ MIDDLEWARE = [
     'django.contrib.sessions.middleware.SessionMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
-    'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
@@ -151,8 +150,13 @@ WSGI_APPLICATION = 'crank.wsgi.application'
 
 EXTENSIONS_MAX_UNIQUE_QUERY_ATTEMPTS = 1000
 
-SESSION_ENGINE = "django.contrib.sessions.backends.cache"
-SESSION_CACHE_ALIAS = 'default'
+# Use the database (not Redis) for sessions. django-allauth stashes the OAuth
+# state into the session between /accounts/google/login/ and the callback at
+# /accounts/google/login/callback/; if Redis evicts that key under memory
+# pressure, allauth can't verify state and renders "Third-Party Login Failure".
+# The shared Redis master is a single 256Mi replica with no persistence, so
+# keep sessions on the durable MySQL store instead.
+SESSION_ENGINE = "django.contrib.sessions.backends.db"
 SESSION_SAVE_EVERY_REQUEST = False
 SESSION_COOKIE_DOMAIN = ".crank.fyi"
 SESSION_COOKIE_SECURE = False

--- a/crank/settings/prod.py
+++ b/crank/settings/prod.py
@@ -45,6 +45,11 @@ DATABASES = {
 }
 ALLOWED_HOSTS = ['*']
 ACCOUNT_DEFAULT_HTTP_PROTOCOL = 'https'
+# Cloudflare terminates TLS and forwards to the k8s NodePort over plain HTTP,
+# so Django sees request.scheme == 'http'. Trust the proxy's forwarded header
+# so is_secure() / build_absolute_uri() report https and the OAuth redirect_uri
+# stays consistent between login initiation and the token-exchange callback.
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,


### PR DESCRIPTION
The /accounts/google/login/callback/ flow was failing because allauth could not find the OAuth state stashed in the session between login initiation and the callback. Sessions were backed by the shared Redis master (single 256Mi replica, no persistence), which evicts session keys under memory pressure, silently dropping the state and rendering allauth's authentication_error page.

- Move SESSION_ENGINE to the db-backed store so OAuth state survives Redis pressure.
- Add SECURE_PROXY_SSL_HEADER so Django sees https behind Cloudflare, keeping the redirect_uri consistent for the token exchange.
- Remove a duplicate CommonMiddleware entry.