### PR TITLE
Force HTTPS and log allauth callback errors

### DIFF
--- a/crank/adapters.py
+++ b/crank/adapters.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2024 Isaac Adams
+# Licensed under the MIT License. See LICENSE file in the project root for full license information.
+"""Custom allauth adapters.
+
+django-allauth's default ``SocialAccountAdapter.on_authentication_error`` is a
+no-op, so the underlying exception that triggers the stock "Third-Party Login
+Failure" page (``OAuth2Error``, ``requests.RequestException``,
+``ProviderException``, ``PermissionDenied``) is silently swallowed and never
+appears in the logs. That makes the callback failure impossible to diagnose in
+production. This adapter logs the provider, error code, and exception so the
+real cause (token-exchange rejection, egress failure, clock skew, ...) is
+visible without surfacing it to the user.
+"""
+import logging
+
+from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
+
+logger = logging.getLogger("users")
+
+
+class SocialAccountAdapter(DefaultSocialAccountAdapter):
+    def on_authentication_error(
+        self,
+        request,
+        provider,
+        error=None,
+        exception=None,
+        extra_context=None,
+    ):
+        logger.warning(
+            "socialaccount authentication error: provider=%s path=%s "
+            "error=%r exception=%r",
+            getattr(provider, "id", provider),
+            request.path,
+            error,
+            exception,
+            exc_info=exception,
+        )
+        return super().on_authentication_error(
+            request,
+            provider,
+            error=error,
+            exception=exception,
+            extra_context=extra_context,
+        )

--- a/crank/settings/base.py
+++ b/crank/settings/base.py
@@ -213,6 +213,10 @@ SOCIALACCOUNT_LOGIN_ON_GET = True
 LOGIN_REDIRECT_URL = '/'
 LOGOUT_REDIRECT_URL = '/'
 
+# Log the underlying exception behind allauth's stock "Third-Party Login
+# Failure" page instead of swallowing it.
+SOCIALACCOUNT_ADAPTER = 'crank.adapters.SocialAccountAdapter'
+
 SOCIALACCOUNT_PROVIDERS = {
     'google': {
         'SCOPE': [

--- a/crank/settings/prod.py
+++ b/crank/settings/prod.py
@@ -13,7 +13,14 @@ pymysql.install_as_MySQLdb()
 
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 DEBUG = False
-# SECURE_SSL_REDIRECT = True
+# Force HTTP -> HTTPS. Without this, a request to http://crank.fyi/accounts/google/login/
+# reaches Django over plain HTTP and sets a Secure session cookie that the browser drops,
+# so the OAuth state stashed at login is gone by the time the HTTPS callback arrives and
+# allauth renders "Third-Party Login Failure". Cloudflare should also "Always Use HTTPS",
+# but enforce it at the origin too so the flow can't start on the wrong scheme.
+SECURE_SSL_REDIRECT = True
+SECURE_HSTS_SECONDS = 31536000
+SECURE_HSTS_INCLUDE_SUBDOMAINS = True
 SECRET_KEY = os.environ.get('SECRET_KEY')
 CPU_COUNT = multiprocessing.cpu_count()
 

--- a/crank/tests/test_adapters.py
+++ b/crank/tests/test_adapters.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2024 Isaac Adams
+# Licensed under the MIT License. See LICENSE file in the project root for full license information.
+from unittest.mock import MagicMock
+
+from django.test import RequestFactory, TestCase
+
+from crank.adapters import SocialAccountAdapter
+
+
+class SocialAccountAdapterTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.adapter = SocialAccountAdapter()
+        self.request = self.factory.get("/accounts/google/login/callback/")
+
+    def test_on_authentication_error_logs_provider_path_error_exception(self):
+        provider = MagicMock(id="google")
+        exception = ValueError("boom")
+
+        with self.assertLogs("users", level="WARNING") as captured:
+            result = self.adapter.on_authentication_error(
+                self.request,
+                provider,
+                error="unknown",
+                exception=exception,
+            )
+
+        # The default adapter is a no-op and returns None; rendering is handled
+        # by allauth's render_authentication_error() via ImmediateHttpResponse.
+        self.assertIsNone(result)
+        self.assertEqual(len(captured.records), 1)
+        message = captured.records[0].getMessage()
+        self.assertIn("google", message)
+        self.assertIn("/accounts/google/login/callback/", message)
+        self.assertIn("unknown", message)
+        self.assertIn("boom", message)
+        # exc_info must be attached so the traceback is logged, not just the str.
+        self.assertIs(captured.records[0].exc_info[1], exception)
+
+    def test_on_authentication_error_accepts_provider_string(self):
+        with self.assertLogs("users", level="WARNING") as captured:
+            self.adapter.on_authentication_error(
+                self.request,
+                "google",
+                error="cancelled",
+                exception=None,
+            )
+
+        self.assertEqual(len(captured.records), 1)
+        self.assertIn("google", captured.records[0].getMessage())


### PR DESCRIPTION
## Summary
Follow-up to the session/persistence fix (#1). The Google OAuth callback still failed because the login flow could start over plain HTTP.

- **Root cause:** `SECURE_SSL_REDIRECT` was commented out (`crank/settings/prod.py:16`). `http://crank.fyi/accounts/google/login/` reached Django over plain HTTP and set a `Secure` session cookie the browser drops, so the OAuth state stashed at login was gone by the time the HTTPS callback arrived → allauth's stock "Third-Party Login Failure". Verified live: `curl http://crank.fyi/accounts/google/login/` 302s to Google with a `Secure` cookie and no HSTS; the HTTPS state round-trip succeeds. Enable `SECURE_SSL_REDIRECT` + HSTS. Cloudflare should also "Always Use HTTPS".
- **Diagnostics:** allauth 65.3.0's default `on_authentication_error` is a no-op, so the underlying `OAuth2Error`/`RequestException`/`ProviderException` is silently swallowed. Added `crank.adapters.SocialAccountAdapter` that logs provider/path/error/exception (with `exc_info`) to the `users` logger, then delegates to default behavior.

## Changes
- `crank/settings/prod.py`: `SECURE_SSL_REDIRECT`, `SECURE_HSTS_SECONDS`, `SECURE_HSTS_INCLUDE_SUBDOMAINS`.
- `crank/settings/base.py`: `SOCIALACCOUNT_ADAPTER = 'crank.adapters.SocialAccountAdapter'`.
- `crank/adapters.py`: new logging adapter (subclass of `DefaultSocialAccountAdapter`).

## Test plan
- [x] `python manage.py check` (dev settings) — no issues
- [x] `python -m pytest` — 38 passed
- [x] Adapter import + wiring verified (subclass of `DefaultSocialAccountAdapter`)
- [ ] Deploy; confirm `curl -I http://crank.fyi/accounts/google/login/` returns 301 to `https://`
- [ ] Confirm a Google login round-trip succeeds on crank.fyi
- [ ] Reuse an old `code` and confirm a `WARNING` from the `users` logger appears with the real `OAuth2Error`

## Follow-ups (not in this PR)
- Canonicalize `www.crank.fyi` -> `crank.fyi` (Cloudflare) so `redirect_uri` host is consistent.
- Verify every pod shares the same `SECRET_KEY`; a mismatch invalidates shared DB sessions when the callback lands on another pod.
- Replace `runserver` (`Dockerfile` CMD) with `gunicorn` for production.

Made with [Cursor](https://cursor.com)