### PR TITLE
Revert SECURE_SSL_REDIRECT to fix pod crashloop

### DIFF
--- a/crank/settings/prod.py
+++ b/crank/settings/prod.py
@@ -13,14 +13,12 @@ pymysql.install_as_MySQLdb()
 
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 DEBUG = False
-# Force HTTP -> HTTPS. Without this, a request to http://crank.fyi/accounts/google/login/
-# reaches Django over plain HTTP and sets a Secure session cookie that the browser drops,
-# so the OAuth state stashed at login is gone by the time the HTTPS callback arrives and
-# allauth renders "Third-Party Login Failure". Cloudflare should also "Always Use HTTPS",
-# but enforce it at the origin too so the flow can't start on the wrong scheme.
-SECURE_SSL_REDIRECT = True
-SECURE_HSTS_SECONDS = 31536000
-SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+# NOTE: SECURE_SSL_REDIRECT must stay disabled. Production runs Django's dev
+# server (`manage.py runserver`, HTTP-only) on port 8080 behind Cloudflare.
+# Enabling SSL redirect here makes Django return 301 -> https for every
+# request; Cloudflare then opens a TLS connection to the HTTP-only origin,
+# the dev server cannot speak TLS, and the liveness probe fails -> crashloop.
+# Enforce HTTPS at the Cloudflare edge ("Always Use HTTPS") instead.
 SECRET_KEY = os.environ.get('SECRET_KEY')
 CPU_COUNT = multiprocessing.cpu_count()
 


### PR DESCRIPTION
## Summary

Merging #299 caused pods to crashloop. Root cause: `SECURE_SSL_REDIRECT = True` is incompatible with this deployment's runtime.

- Production runs Django's **dev server** (`manage.py runserver`) on port 8080 (`Dockerfile` CMD), which only speaks HTTP. The startup log confirms: `Starting development server at http://0.0.0.0:8080/`.
- `SECURE_SSL_REDIRECT = True` (added in 37cc74af) makes Django return `301 -> https` for every request. Cloudflare then opens a TLS connection to the HTTP-only origin; the dev server cannot speak TLS, so the TLS ClientHello is parsed as a malformed HTTP request.
- This matches the crashloop logs exactly:
  - `code 400, message Bad request version ('\x16\x03\x01...')` — those bytes are a TLS ClientHello hitting the HTTP port.
  - `You're accessing the development server over HTTPS, but it only supports HTTP.`
  - Repeated `GET / HTTP/1.1 301 0` (the SSL redirect) followed by the TLS 400s.
- The liveness probe (`httpGet` on port 8080, `k8s/crank.yml`) stops getting healthy responses → kubelet restarts the pod → crashloop.

## Fix

- Disable `SECURE_SSL_REDIRECT` and the `SECURE_HSTS_*` settings in `crank/settings/prod.py`, with a comment explaining why they must stay off while the origin is HTTP-only.
- HTTPS must be enforced at the **Cloudflare edge** ("Always Use HTTPS"), not at the origin. That is the correct layer for the original OAuth issue (preventing the flow from starting on `http://`) given an HTTP-only origin behind Cloudflare.
- The allauth logging adapter (`crank/adapters.py`) from #299 is retained — it is harmless and useful for diagnosing any residual callback failures.

## Test plan
- [x] `python manage.py check` (dev settings) — no issues
- [x] `python -m pytest` — 40 passed
- [ ] Deploy; confirm pods stop crashlooping and `/` returns 200 (not 301)
- [ ] Enable Cloudflare "Always Use HTTPS" and confirm `http://crank.fyi/accounts/google/login/` redirects to `https://` at the edge before reaching the origin

## Follow-ups (not in this PR)
- Replace `runserver` with `gunicorn` for production; only then could origin-side SSL redirect/HSTS be reconsidered.
- Canonicalize `www.crank.fyi` -> `crank.fyi` at Cloudflare.

Made with [Cursor](https://cursor.com)