### PR TITLE
Resolve DB host 'fats' inside pods via hostAliases

### DIFF
--- a/k8s/crank.yml
+++ b/k8s/crank.yml
@@ -33,6 +33,15 @@ spec:
         runAsUser: 10000
         runAsGroup: 10000
         fsGroup: 10000
+      # `fats` is the k3s host (10.0.0.10) that runs the MySQL database on
+      # :3306. It is not a Kubernetes Service and does not resolve via in-cluster
+      # DNS, so DB_HOST=fats fails with EAI_AGAIN inside containers. Inject the
+      # mapping into each pod's /etc/hosts so the hostname resolves without
+      # depending on DNS or hardcoding the IP in the ConfigMap.
+      hostAliases:
+        - ip: "10.0.0.10"
+          hostnames:
+            - "fats"
       containers:
         - name: crank-container
           image: ghcr.io/norcalipa/crank/crank:${GITHUB_SHA}


### PR DESCRIPTION
## Summary

Fixes the pod crashloop where pods fail to boot with:
```
socket.gaierror: [Errno -3] Try again
pymysql.err.OperationalError: (2003, "Can't connect to MySQL server on 'fats' ([Errno -3] Try again)")
```

## Root cause

`DB_HOST=fats` (`k8s/crank-configmap.yml:10`), but `fats` is the **bare hostname of the k3s host** (10.0.0.10) that runs the MySQL database on :3306 — it is **not** a Kubernetes Service and does not resolve via in-cluster DNS. Inside containers, `getaddrinfo("fats")` returns `EAI_AGAIN`, so the DB connect at `manage.py runserver` startup (`check_migrations()`) raises, the main thread dies, and kubelet restarts the pod → crashloop.

This is not caused by the recent settings changes (session/SSL/adapter) — those don't touch DB connectivity. The DB itself is up and reachable on `fats:3306` from the host; only in-container name resolution is broken.

## Fix

Add a `hostAliases` entry to the crank Deployment (`k8s/crank.yml`) mapping `fats` -> `10.0.0.10`. Kubernetes injects this into each pod's `/etc/hosts`, so `fats` resolves inside every container without depending on CoreDNS or hardcoding the IP in the ConfigMap.

```yaml
spec:
  template:
    spec:
      hostAliases:
        - ip: "10.0.0.10"
          hostnames:
            - "fats"
```

## Test plan
- [x] `k8s/crank.yml` parses as valid multi-doc YAML
- [ ] Merge triggers `update-home-deployment.yml` (it watches `k8s/crank.yml`) and re-applies the Deployment
- [ ] On a rolled pod: `k3s kubectl -n crank exec deploy/crank -- getent hosts fats` returns `10.0.0.10 fats`
- [ ] Pods stop crashlooping and `/` returns 200

## Notes / follow-ups
- If the k3s host IP ever changes, update the `hostAliases` IP (or move the DB behind a real `Service`/`ExternalName` so DNS handles it).
- The `manage.py runserver`-in-production issue remains a separate hardening item (gunicorn); not addressed here.

Made with [Cursor](https://cursor.com)