### PR TITLE
Add public DNS fallback so pods can resolve external names

### DIFF
--- a/k8s/crank.yml
+++ b/k8s/crank.yml
@@ -42,6 +42,24 @@ spec:
         - ip: "10.0.0.10"
           hostnames:
             - "fats"
+      # In-cluster DNS (CoreDNS) cannot resolve external names in this cluster
+      # (the node's upstream resolver is unreachable from pods), so the OAuth
+      # token exchange fails: `Failed to resolve 'oauth2.googleapis.com'
+      # ([Errno -3] Try again)`. With dnsPolicy: ClusterFirst the cluster DNS is
+      # prepended (so in-cluster names like `redis-master` still resolve) and
+      # these public nameservers are appended as fallbacks for external names.
+      # The resolver tries the next server on a temporary failure (EAI_AGAIN),
+      # so external queries succeed via 8.8.8.8 / 1.1.1.1.
+      dnsPolicy: ClusterFirst
+      dnsConfig:
+        nameservers:
+          - 8.8.8.8
+          - 1.1.1.1
+        options:
+          - name: timeout
+            value: "2"
+          - name: attempts
+            value: "3"
       containers:
         - name: crank-container
           image: ghcr.io/norcalipa/crank/crank:${GITHUB_SHA}


### PR DESCRIPTION
## Summary

The `fats` hostAliases fix (#301) stopped the crashloop, but Google OAuth still failed. The logging adapter from #299 finally surfaced the real error:

```
WARNING users.on_authentication_error: socialaccount authentication error: provider=google
  path=/accounts/google/login/callback/ error='unknown'
  exception=ConnectionError(MaxRetryError('HTTPSConnectionPool(host=oauth2.googleapis.com, port=443):
  Max retries exceeded with url: /token (Caused by NameResolutionError("...
  Failed to resolve \'oauth2.googleapis.com\' ([Errno -3] Try again)"))'))
```

## Root cause

In-cluster DNS (CoreDNS) cannot resolve **external** names in this cluster — the node's upstream resolver is unreachable from pods (the classic k3s "pods can't resolve external DNS" situation, e.g. node `/etc/resolv.conf` pointing at a loopback stub resolver CoreDNS can't reach). So the OAuth token-exchange POST to `https://oauth2.googleapis.com/token` fails with `NameResolutionError ... [Errno -3] Try again` (EAI_AGAIN), allauth catches the `requests.ConnectionError` and renders its stock "Third-Party Login Failure" page.

This is the same class of in-container DNS breakage as the `fats` issue, but `hostAliases` can't help here (Google's IPs are dynamic/many). The proper cluster-wide fix is to repair CoreDNS upstream forwarding, but a robust, self-contained per-pod workaround is `dnsConfig`.

## Fix

Add `dnsConfig` with public nameservers to the crank Deployment (`k8s/crank.yml`), keeping `dnsPolicy: ClusterFirst`:

```yaml
dnsPolicy: ClusterFirst
dnsConfig:
  nameservers:
    - 8.8.8.8
    - 1.1.1.1
  options:
    - name: timeout
      value: "2"
    - name: attempts
      value: "3"
```

Per Kubernetes merge semantics (`appendDNSConfig` in kubelet `network/dns/dns.go`), with `ClusterFirst` the **cluster DNS is prepended** and these custom nameservers are **appended** (duplicates removed, max 3). So the pod's `/etc/resolv.conf` becomes `nameserver <clusterDNS> \n nameserver 8.8.8.8 \n nameserver 1.1.1.1`:
- In-cluster names (`redis-master`) → resolved by CoreDNS (first), unaffected.
- External names (`oauth2.googleapis.com`) → CoreDNS returns a temporary failure (EAI_AGAIN, matching the logs), and the resolver falls back to `8.8.8.8`/`1.1.1.1`, which resolves.

`timeout: 2` / `attempts: 3` make the failover snappier. The default `ndots:5` and cluster search domains are preserved by the merge, so in-cluster short names keep working.

## Test plan
- [x] `k8s/crank.yml` parses as valid multi-doc YAML
- [ ] Merge triggers `update-home-deployment.yml` (watches `k8s/crank.yml`) and re-applies the Deployment
- [ ] On a rolled pod: `k3s kubectl -n crank exec deploy/crank -- cat /etc/resolv.conf` shows the cluster DNS plus 8.8.8.8 / 1.1.1.1
- [ ] `k3s kubectl -n crank exec deploy/crank -- getent hosts oauth2.googleapis.com` resolves
- [ ] Complete a Google login round-trip on crank.fyi and confirm no "Third-Party Login Failure"

## Notes / follow-ups
- The durable cluster-wide fix is to point CoreDNS's `forward` plugin (the `kube-system/coredns` ConfigMap) at `8.8.8.8 1.1.1.1` instead of `/etc/resolv.conf`, then restart CoreDNS — that repairs external DNS for every pod, not just `crank`. Worth doing separately.
- Requires pod egress to `8.8.8.8:53`/`1.1.1.1:53` (UDP/TCP). No NetworkPolicy in this repo restricts egress, and the pods already need internet egress (New Relic, Google), so this should be fine.

Made with [Cursor](https://cursor.com)